### PR TITLE
Update README.md to fix simple test

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ async def test_devices_list():
     async with ClientSession() as session:
         thinq_api = ThinQApi(session=session, access_token='your_personal_access_token', country_code='your_contry_code', client_id='your_client_id')
         response = await thinq_api.async_get_device_list()
-        print("device_list : %s", response.body)
+        print("device_list : %s", response)
 
 asyncio.run(test_devices_list())
 ```


### PR DESCRIPTION
Updating the README.md file to fix the initial example provided by the repository. The output from async_get_route (in this case, response) is either a dictionary or a list and will not contain the body attribute. The wrong example may cause confusion for users trying the lib for the first time.