### PR TITLE
Add missing properties in dehumidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,9 @@ For detailed information on Device Properties, please refer to the following pag
 |  1 | operation               | dehumidifier\_operation\_mode |
 |  2 | dehumidifier\_job\_mode | current\_job\_mode            |
 |  3 | humidity                | current\_humidity             |
-|  4 | air\_flow               | wind\_strength                |
+|  4 | humidity                | target\_humidity              |
+|  5 | air\_flow               | wind\_strength                |
+|  6 | air\_flow               | wind\_strength\_level         |
 
 
 ### DEVICE\_DISH\_WASHER

--- a/thinqconnect/devices/const.py
+++ b/thinqconnect/devices/const.py
@@ -274,6 +274,7 @@ class Property(StrEnum):
     WIND_ROTATE_UP_DOWN = auto()
     WIND_STEP = auto()
     WIND_STRENGTH = auto()
+    WIND_STRENGTH_LEVEL = auto()
     WIND_TEMPERATURE = auto()
     WIND_VOLUME = auto()
     WORT_INFO = auto()

--- a/thinqconnect/devices/dehumidifier.py
+++ b/thinqconnect/devices/dehumidifier.py
@@ -25,7 +25,10 @@ class DehumidifierProfile(ConnectDeviceProfile):
                 "operation": {"dehumidifierOperationMode": Property.DEHUMIDIFIER_OPERATION_MODE},
                 "dehumidifierJobMode": {"currentJobMode": Property.CURRENT_JOB_MODE},
                 "humidity": {"currentHumidity": Property.CURRENT_HUMIDITY},
-                "airFlow": {"windStrength": Property.WIND_STRENGTH},
+                "airFlow": {
+                    "windStrength": Property.WIND_STRENGTH,
+                    "windStrengthLevel": Property.WIND_STRENGTH_LEVEL,
+                },
             },
         )
 
@@ -63,3 +66,6 @@ class DehumidifierDevice(ConnectBaseDevice):
 
     async def set_wind_strength(self, wind_strength: str) -> dict | None:
         return await self.do_enum_attribute_command(Property.WIND_STRENGTH, wind_strength)
+
+    async def set_wind_strength_level(self, wind_strength_level: str) -> dict | None:
+        return await self.do_enum_attribute_command(Property.WIND_STRENGTH_LEVEL, wind_strength_level)

--- a/thinqconnect/devices/dehumidifier.py
+++ b/thinqconnect/devices/dehumidifier.py
@@ -24,7 +24,10 @@ class DehumidifierProfile(ConnectDeviceProfile):
             profile_map={
                 "operation": {"dehumidifierOperationMode": Property.DEHUMIDIFIER_OPERATION_MODE},
                 "dehumidifierJobMode": {"currentJobMode": Property.CURRENT_JOB_MODE},
-                "humidity": {"currentHumidity": Property.CURRENT_HUMIDITY},
+                "humidity": {
+                    "currentHumidity": Property.CURRENT_HUMIDITY,
+                    "targetHumidity": Property.TARGET_HUMIDITY,
+                },
                 "airFlow": {
                     "windStrength": Property.WIND_STRENGTH,
                     "windStrengthLevel": Property.WIND_STRENGTH_LEVEL,


### PR DESCRIPTION
Added missing properties in dehumidifier.
This is based on `DQ235MWGA` model's response, which is recognized as `DHUM_231006_WW`

reference: https://smartsolution.developer.lge.com/en/apiManage/device_profile?s=1751854291029#tag/dehumidifier