### PR TITLE
Fix stale timer cache when LG devices omit zero-value fields

### DIFF
--- a/thinqconnect/devices/connect_device.py
+++ b/thinqconnect/devices/connect_device.py
@@ -420,6 +420,11 @@ class ConnectBaseDevice(BaseDevice):
             if is_updated:
                 if prop_key in resource_status:
                     self._set_status_attr(prop_attr, value)
+                elif resource == "timer":
+                    # LG devices omit timer fields (e.g. remainHour) when their value
+                    # is 0 instead of sending an explicit 0. Clear the cached value so
+                    # it does not persist across incremental MQTT updates.
+                    self._set_status_attr(prop_attr, None)
                 return
 
         self._set_status_attr(prop_attr, value)


### PR DESCRIPTION
## Problem

LG devices omit timer fields (e.g. `remainHour`) from MQTT incremental updates when their value is 0, rather than sending an explicit `0`. The incremental-update logic in `__set_property_status` preserves the cached value when a field is absent from the payload, so the cached hour persists and the computed remaining time appears ~1 hour too long.

**Affected devices:** Washer, Dryer (any device with a `timer` resource that uses `remainHour`/`remainMinute`)

### Reproducer

```
MQTT update: {"remainHour": 1, "remainMinute": 0}  → remain = 01:00  ✓
MQTT update: {"remainMinute": 59}                   → remain = 01:59  ✗ (should be 00:59)
```

This happens every time the countdown crosses an hour boundary, and also when switching wash programs (preview payloads include `remainHour`, the actual short program does not).

Related HA issue: https://github.com/home-assistant/core/issues/159194

## Fix

When processing a `timer` resource update and a field is **absent** from the incremental payload, explicitly clear the cached value to `None` instead of leaving it unchanged.

```python
elif resource == "timer":
    # LG devices omit timer fields (e.g. remainHour) when their value
    # is 0 instead of sending an explicit 0. Clear the cached value so
    # it does not persist across incremental MQTT updates.
    self._set_status_attr(prop_attr, None)
```

## Testing

Verified on a live LG ThinQ Washer (FAFXK24005) and Dryer (BDH_D30006_TW) via Home Assistant MQTT logs. Both devices triggered the hour-boundary omission pattern during a full wash/dry cycle; with this fix applied the sensor correctly transitions from `01:00` → `00:59` instead of `01:59`.

Log evidence of the fix working (sensor `update status`):
```
17:12:01  MQTT: {remainHour: 1, remainMinute: 0}  →  sensor: 01:00:00
17:13:02  MQTT: {remainMinute: 59}                →  sensor: 00:59:00  ✓
```