### PR TITLE
fix: fix two bugs in mqtt_client.py (state assignment typo + None check order)

### DIFF
--- a/thinqconnect/mqtt_client.py
+++ b/thinqconnect/mqtt_client.py
@@ -150,11 +150,12 @@ class ThinQMQTTClient:
     async def generate_csr(self) -> bool:
         """Create CSR."""
         cert_data = await self._get_root_certificate()
-        self.bytes_root_ca = cert_data.encode("utf-8")
 
         if cert_data is None:
             _LOGGER.error("Root certification download failed")
             return False
+
+        self.bytes_root_ca = cert_data.encode("utf-8")
 
         key = crypto.PKey()
         key.generate_key(crypto.TYPE_RSA, PRIVATE_KEY_SIZE)

--- a/thinqconnect/mqtt_client.py
+++ b/thinqconnect/mqtt_client.py
@@ -262,11 +262,10 @@ class ThinQMQTTClient:
                 "Connect with session_present : %s",
                 connect_result["session_present"],
             )
-            self._state == ClientConnectionState.CLIENT_CONNECTED
+            self._state = ClientConnectionState.CLIENT_CONNECTED
         except Exception as err:
             _LOGGER.error("Failed to connect endpoint: %s", err)
             return None
-        self._state = ClientConnectionState.CLIENT_CONNECTED
         self._mqtt_connection = mqtt_connection
         if self._mqtt_connection is not None:
             try:


### PR DESCRIPTION
## Summary
Fix two bugs in `thinqconnect/mqtt_client.py`:

## Changes
- `async_connect_mqtt`: `self._state ==` → `self._state =`, removed duplicate assignment
- `generate_csr`: moved `self.bytes_root_ca = cert_data.encode("utf-8")` after `if cert_data is None`

### Bug 1:  fix: replace comparison (==) with assignment (=) for _state in async_connect_mqtt
- `self._state == ClientConnectionState.CLIENT_CONNECTED` (line 265) was a  no-op comparison. Changed `==` to `=` and removed the redundant duplicate assignment outside the try block.

### Bug 2: fix: move bytes_root_ca assignment after None check in generate_csr
- `cert_data.encode("utf-8")` was called before checking if `cert_data is None`,
  causing `AttributeError` when `_get_root_certificate()` fails.
  Moved the assignment after the None guard.