### PR TITLE
fix: correct month slice index in _get_date_type_instance

### DIFF
--- a/thinqconnect/devices/connect_device.py
+++ b/thinqconnect/devices/connect_device.py
@@ -507,7 +507,7 @@ class ConnectBaseDevice(BaseDevice):
             return None, None
 
         year = int(date_str[:4])
-        month = int(date_str[5:6])
+        month = int(date_str[4:6])
         day = int(date_str[6:]) if date_type == USAGE_DAILY else 1
 
         try:


### PR DESCRIPTION
## Summary
In `_get_date_type_instance()`, `date_str[5:6]` only extracts a single character producing incorrect month values 
(e.g. '2' from '20241215').
Changed to date_str[4:6] to correctly extract the two-digit month (e.g. '12').

## Fix
Changed `date_str[5:6]` to `date_str[4:6]` to correctly extract the two-digit month.