### PR TITLE
fix: swap windStrength preferred keys order to expose AUTO fan mode

### DIFF
--- a/thinqconnect/devices/air_conditioner.py
+++ b/thinqconnect/devices/air_conditioner.py
@@ -84,7 +84,7 @@ class AirConditionerProfile(ConnectDeviceProfile):
                 },
                 "airFlow": {
                     self._get_preferred_property_key(
-                        profile, "airFlow", ["windStrengthDetail", "windStrength"]
+                        profile, "airFlow", ["windStrength", "windStrengthDetail"]
                     ): Property.WIND_STRENGTH,
                     "windStep": Property.WIND_STEP,
                 },


### PR DESCRIPTION
## Summary

Fixes the remaining bug after upstream 1.0.13 partially addressed #43.

Fixes #43

## Problem

Upstream 1.0.13 changed `specification.py` to `fan_mode_keys=(ThinQProperty.WIND_STRENGTH,)`, removing `WIND_STEP` entirely. This resolved the fan mode priority issue.

However, `_get_preferred_property_key()` in `air_conditioner.py` still lists `windStrengthDetail` before `windStrength`, so the `PropertyHolder` for `WIND_STRENGTH` returns options without `AUTO`.

## Change

**`thinqconnect/devices/air_conditioner.py`** — Swap preferred keys order:

```python
# Before
self._get_preferred_property_key(
    profile, "airFlow", ["windStrengthDetail", "windStrength"]
): Property.WIND_STRENGTH,

# After
self._get_preferred_property_key(
    profile, "airFlow", ["windStrength", "windStrengthDetail"]
): Property.WIND_STRENGTH,
```

## Impact

- Devices with both `windStep` and `windStrength` (e.g. RAC_056905_WW): AUTO fan mode becomes available
- Devices with only `windStrengthDetail`: unaffected (fallback returns `windStrengthDetail`)
- Devices with only `windStep`: unaffected (no `WIND_STRENGTH` holder exists)

## Testing

Verified on RAC_056905_WW with both properties in profile. The LG API accepts `{"airFlow": {"windStrength": "AUTO"}}` — confirmed via direct control call.
