### PR TITLE
Replace pyOpenSSL with cryptography for CSR generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     python_requires=">=3.10",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["aiohttp>=3.14.0", "awsiotsdk", "pyOpenSSL"],
+    install_requires=["aiohttp>=3.14.0", "awsiotsdk", "cryptography"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: Apache Software License",

--- a/thinqconnect/mqtt_client.py
+++ b/thinqconnect/mqtt_client.py
@@ -15,7 +15,10 @@ from typing import Callable
 from aiohttp import ClientTimeout, request
 from awscrt import io, mqtt
 from awsiot import mqtt_connection_builder
-from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 
 from .thinq_api import ThinQApi
 
@@ -157,17 +160,20 @@ class ThinQMQTTClient:
 
         self.bytes_root_ca = cert_data.encode("utf-8")
 
-        key = crypto.PKey()
-        key.generate_key(crypto.TYPE_RSA, PRIVATE_KEY_SIZE)
-        key_pem = crypto.dump_privatekey(crypto.FILETYPE_PEM, key).decode("utf-8")
-        self.bytes_private_key = key_pem.encode("utf-8")
+        key = rsa.generate_private_key(public_exponent=65537, key_size=PRIVATE_KEY_SIZE)
+        self.bytes_private_key = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
 
-        csr = crypto.X509Req()
-        csr.get_subject().CN = "lg_thinq"
-        csr.set_pubkey(key)
-        csr.sign(key, "sha512")
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "lg_thinq")]))
+            .sign(key, hashes.SHA512())
+        )
 
-        csr_pem = crypto.dump_certificate_request(crypto.FILETYPE_PEM, csr).decode(encoding="utf-8")
+        csr_pem = csr.public_bytes(serialization.Encoding.PEM).decode(encoding="utf-8")
         self.csr_str = (
             re.search(
                 r"-+BEGIN CERTIFICATE REQUEST-+\s+(.*?)\s+-+END CERTIFICATE REQUEST-+",


### PR DESCRIPTION
## Why

pyOpenSSL 26.3.0 (released June 2026) removed the long-deprecated `OpenSSL.crypto.X509Req` and `OpenSSL.crypto.dump_certificate_request` APIs. `ThinQMQTTClient.generate_csr` uses both, so with pyOpenSSL 26.3.0 installed, CSR generation fails with `AttributeError` and the MQTT connection can never be established.

This currently blocks Home Assistant from upgrading to pyOpenSSL 26.3.0 / cryptography 49.0.0 without breaking the `lg_thinq` integration (see the deprecation notes in the [pyOpenSSL changelog](https://github.com/pyca/pyopenssl/blob/main/CHANGELOG.rst)).

## What

Migrates key and CSR generation in `thinqconnect/mqtt_client.py` from pyOpenSSL to the `cryptography` package APIs, which is the replacement pyOpenSSL's own deprecation messages recommend. The output is functionally identical:

- Private key: 2048-bit RSA, PEM-encoded PKCS#8 (same `-----BEGIN PRIVATE KEY-----` format `dump_privatekey` produced)
- CSR: subject `CN=lg_thinq`, signed with SHA-512, PEM-encoded (the existing base64 extraction regex is unchanged)

Since this was the only pyOpenSSL usage in the package, `setup.py` now depends on `cryptography` directly instead of `pyOpenSSL`. The `cryptography` APIs used here (`rsa.generate_private_key`, `CertificateSigningRequestBuilder`) have been stable for many years, so this works with both old and new cryptography versions — no minimum version bump is needed.

## Verification

Ran `generate_csr` with a mocked root CA download and validated the result with `cryptography`: the CSR signature is valid, subject CN is `lg_thinq`, signature hash is SHA-512, the CSR public key matches the generated private key, and the key PEM header is unchanged.