### PR TITLE
Fix missing set_relative_hour_to_stop for AC

### DIFF
--- a/thinqconnect/devices/air_conditioner.py
+++ b/thinqconnect/devices/air_conditioner.py
@@ -404,6 +404,12 @@ class AirConditionerDevice(ConnectBaseDevice):
             }
         )
 
+    async def set_relative_hour_to_start(self, hour: int) -> dict | None:
+        return await self.set_relative_time_to_start(hour=hour, minute=0)
+
+    async def set_relative_hour_to_stop(self, hour: int) -> dict | None:
+        return await self.set_relative_time_to_stop(hour=hour, minute=0)
+
     async def set_absolute_time_to_start(self, hour: int, minute: int) -> dict | None:
         return await self.do_multi_attribute_command(
             {


### PR DESCRIPTION
- Added missing set_relative_hour_to_stop and set_relative_hour_to_start methods for ac

Fixes the issue where the AC won't respond to `RELATIVE_HOUR_TO_STOP/START` Home Assistant setters