### PR TITLE
Fix AttributeError in async_disconnect when MQTT connect failed

### DIFF
--- a/thinqconnect/mqtt_client.py
+++ b/thinqconnect/mqtt_client.py
@@ -282,5 +282,6 @@ class ThinQMQTTClient:
 
     async def async_disconnect(self) -> None:
         """Unregister client and disconnects handlers"""
-        self._mqtt_connection.unsubscribe(topic=self.topic_subscription)
+        if self._mqtt_connection is not None:
+            self._mqtt_connection.unsubscribe(topic=self.topic_subscription)
         await self._on_disconnect()


### PR DESCRIPTION
## Summary
- `async_connect_mqtt()` returns early without setting `self._mqtt_connection` when the initial connect attempt fails (e.g. a transient network outage causing `AWS_IO_SOCKET_TIMEOUT`), so `self._mqtt_connection` stays at its `__init__` default of `None`.
- `async_disconnect()` then unconditionally calls `self._mqtt_connection.unsubscribe(...)`, raising `AttributeError: 'NoneType' object has no attribute 'unsubscribe'`.
- In Home Assistant's `lg_thinq` integration this propagates up through `async_unload_entry`, permanently wedging the config entry in a `failed_unload` state until HA is restarted.

## Fix
Guard the `unsubscribe` call so disconnecting a client that never finished connecting is a no-op, matching the existing `if self._mqtt_connection is not None:` guard already used around the `subscribe` call in `async_connect_mqtt`.

## Test plan
- [x] Reproduced the crash with a standalone script that constructs a `ThinQMQTTClient` with `_mqtt_connection = None` (the exact post-failed-connect state) and calls `async_disconnect()` — confirmed `AttributeError` before the fix, clean no-op after.
- No existing test suite in this repo to extend.