### PR TITLE
Expose stable oven cook-timer end times in HABridge

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+freezegun>=1.5

--- a/tests/fixtures/oven/device.json
+++ b/tests/fixtures/oven/device.json
@@ -1,0 +1,9 @@
+{
+  "deviceId": "OV-00000000-0000-0000-0000-000000000001",
+  "deviceInfo": {
+    "deviceType": "DEVICE_OVEN",
+    "modelName": "Test oven",
+    "alias": "Test oven",
+    "reportable": true
+  }
+}

--- a/tests/fixtures/oven/profile.json
+++ b/tests/fixtures/oven/profile.json
@@ -1,0 +1,77 @@
+{
+  "extensionProperty": {
+    "info": {
+      "type": "DOUBLE"
+    }
+  },
+  "property": [
+    {
+      "location": {
+        "locationName": "UPPER"
+      },
+      "runState": {
+        "currentState": {
+          "mode": ["r"],
+          "type": "enum",
+          "value": {
+            "r": [
+              "INITIAL",
+              "PREHEATING",
+              "COOKING_IN_PROGRESS",
+              "DONE",
+              "COOLING"
+            ]
+          }
+        }
+      },
+      "timer": {
+        "remainHour": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainMinute": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainSecond": {
+          "mode": ["r"],
+          "type": "number"
+        }
+      }
+    },
+    {
+      "location": {
+        "locationName": "LOWER"
+      },
+      "runState": {
+        "currentState": {
+          "mode": ["r"],
+          "type": "enum",
+          "value": {
+            "r": [
+              "INITIAL",
+              "PREHEATING",
+              "COOKING_IN_PROGRESS",
+              "DONE",
+              "COOLING"
+            ]
+          }
+        }
+      },
+      "timer": {
+        "remainHour": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainMinute": {
+          "mode": ["r"],
+          "type": "number"
+        },
+        "remainSecond": {
+          "mode": ["r"],
+          "type": "number"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/oven/status.json
+++ b/tests/fixtures/oven/status.json
@@ -1,0 +1,28 @@
+[
+  {
+    "location": {
+      "locationName": "UPPER"
+    },
+    "runState": {
+      "currentState": "COOKING_IN_PROGRESS"
+    },
+    "timer": {
+      "remainHour": 0,
+      "remainMinute": 10,
+      "remainSecond": 0
+    }
+  },
+  {
+    "location": {
+      "locationName": "LOWER"
+    },
+    "runState": {
+      "currentState": "COOKING_IN_PROGRESS"
+    },
+    "timer": {
+      "remainHour": 0,
+      "remainMinute": 10,
+      "remainSecond": 0
+    }
+  }
+]

--- a/tests/test_oven_timer_state.py
+++ b/tests/test_oven_timer_state.py
@@ -1,0 +1,150 @@
+"""Test oven timer state through the public Home Assistant bridge."""
+
+import asyncio
+import json
+from datetime import datetime, time, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from freezegun import freeze_time
+
+from thinqconnect import ThinQAPIErrorCodes, ThinQAPIException
+from thinqconnect.devices.oven import OvenDevice
+from thinqconnect.integration import (
+    HABridge,
+    NotConnectedDeviceError,
+    OvenTimerPropertyState,
+    TimerProperty,
+)
+
+START = datetime(2026, 9, 7, 18, 30, tzinfo=timezone.utc)
+FIXTURES = Path(__file__).parent / "fixtures" / "oven"
+
+
+def load_fixture(name):
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+@pytest.fixture
+def freezer():
+    with freeze_time(START) as frozen:
+        yield frozen
+
+
+@pytest.fixture(params=["UPPER", "LOWER", "OVEN"])
+def cavity(request):
+    return request.param
+
+
+@pytest.fixture
+def bridge(freezer, cavity):
+    device_info = load_fixture("device")
+    profile = load_fixture("profile")
+    status = load_fixture("status")
+    if cavity == "OVEN":
+        profile["property"][0]["location"]["locationName"] = "OVEN"
+        status[0]["location"]["locationName"] = "OVEN"
+    api = AsyncMock()
+    api.async_get_device_status.return_value = status
+    device = OvenDevice(
+        thinq_api=api,
+        device_id=device_info["deviceId"],
+        device_type=device_info["deviceInfo"]["deviceType"],
+        model_name=device_info["deviceInfo"]["modelName"],
+        alias=device_info["deviceInfo"]["alias"],
+        profile=profile,
+        energy_profile=None,
+    )
+    device.set_status(status)
+    result = HABridge(device)
+    result.update_status(None)
+    return result
+
+
+@pytest.fixture
+def timer(bridge, cavity):
+    result = bridge.state_map[f"{cavity.lower()}_{TimerProperty.REMAIN}"]
+    assert isinstance(result, OvenTimerPropertyState)
+    return result
+
+
+def push(bridge, cavity, **fields):
+    return bridge.update_status([{"location": {"locationName": cavity}, **fields}])
+
+
+def test_initial_timer_and_stable_countdown(bridge, cavity, timer, freezer):
+    assert timer.value == time(0, 10)
+    assert timer.end_time == START + timedelta(minutes=10)
+    freezer.move_to(START + timedelta(minutes=1, seconds=2))
+    push(bridge, cavity, timer={"remainMinute": 9})
+    assert timer.value == time(0, 9)
+    assert timer.end_time == START + timedelta(minutes=10)
+    freezer.move_to(START + timedelta(minutes=2))
+    push(bridge, cavity, runState={"currentState": "COOKING_IN_PROGRESS"})
+    bridge.update_status(None)
+    assert timer.end_time == START + timedelta(minutes=10)
+
+
+@pytest.mark.parametrize("inactive", ["INITIAL", "DONE", "COOLING"])
+@pytest.mark.parametrize("active", ["PREHEATING", "COOKING_IN_PROGRESS"])
+def test_restart_requires_fresh_timer(bridge, cavity, timer, freezer, inactive, active):
+    push(bridge, cavity, runState={"currentState": inactive})
+    assert timer.end_time is None
+    freezer.move_to(START + timedelta(minutes=20))
+    push(bridge, cavity, runState={"currentState": active})
+    assert timer.end_time is None
+    push(bridge, cavity, timer={"targetMinute": 10})
+    assert timer.end_time is None
+    push(bridge, cavity, timer={"remainMinute": 10})
+    assert timer.end_time == START + timedelta(minutes=30)
+
+
+@pytest.mark.parametrize("minutes", [0, 5, 10, 20])
+def test_adjustment_and_cancellation(bridge, cavity, timer, freezer, minutes):
+    freezer.move_to(START + timedelta(minutes=1))
+    push(bridge, cavity, timer={"remainMinute": minutes})
+    expected = START + timedelta(minutes=1 + minutes) if minutes else None
+    assert timer.end_time == expected
+
+
+def test_timer_received_while_inactive(bridge, cavity, timer):
+    push(bridge, cavity, runState={"currentState": "DONE"}, timer={"remainMinute": 8})
+    assert timer.end_time is None
+    push(bridge, cavity, runState={"currentState": "PREHEATING"})
+    assert timer.end_time is None
+
+
+def test_other_cavity_does_not_extend_timer(bridge, cavity, timer, freezer):
+    other = "LOWER" if cavity != "LOWER" else "UPPER"
+    freezer.move_to(START + timedelta(minutes=3))
+    push(bridge, other, timer={"remainMinute": 5})
+    assert timer.end_time == START + timedelta(minutes=10)
+    assert bridge.state_map[
+        f"{other.lower()}_{TimerProperty.REMAIN}"
+    ].end_time == START + timedelta(minutes=8)
+
+
+def test_full_response_restores_new_timer(bridge, cavity, timer, freezer):
+    push(bridge, cavity, runState={"currentState": "DONE"})
+    assert timer.end_time is None
+    freezer.move_to(START + timedelta(minutes=20))
+    asyncio.run(bridge.fetch_data())
+    assert timer.end_time == START + timedelta(minutes=30)
+
+
+@pytest.mark.parametrize("response", [None, []])
+def test_empty_refresh_cannot_restore_cached_timer(bridge, cavity, timer, response):
+    push(bridge, cavity, runState={"currentState": "DONE"})
+    push(bridge, cavity, runState={"currentState": "COOKING_IN_PROGRESS"})
+    bridge.device.thinq_api.async_get_device_status.return_value = response
+    asyncio.run(bridge.fetch_data())
+    assert timer.end_time is None
+
+
+def test_fetch_preserves_disconnected_error(bridge):
+    bridge.device.thinq_api.async_get_device_status.side_effect = ThinQAPIException(
+        ThinQAPIErrorCodes.NOT_CONNECTED_DEVICE, "Not connected", {}
+    )
+    with pytest.raises(NotConnectedDeviceError):
+        asyncio.run(bridge.fetch_data())

--- a/thinqconnect/integration/__init__.py
+++ b/thinqconnect/integration/__init__.py
@@ -16,7 +16,7 @@ from .homeassistant.specification import (
     ThinQPropertyEx,
     TimerProperty,
 )
-from .homeassistant.state import DeviceState, PropertyState
+from .homeassistant.state import DeviceState, OvenTimerPropertyState, PropertyState
 
 __all__ = [
     "ActiveMode",
@@ -24,6 +24,7 @@ __all__ = [
     "ExtendedProperty",
     "HABridge",
     "NotConnectedDeviceError",
+    "OvenTimerPropertyState",
     "PropertyState",
     "ThinQPropertyEx",
     "TimerProperty",

--- a/thinqconnect/integration/homeassistant/api.py
+++ b/thinqconnect/integration/homeassistant/api.py
@@ -83,6 +83,7 @@ from .state import (
     ExtendedPropertyState,
     PropertyState,
     SelectivePropertyState,
+    OvenTimerPropertyState,
     SinglePropertyState,
     TemperaturePropertyState,
     TimerPropertyState,
@@ -471,6 +472,20 @@ class HABridge:
         second_holder = self._get_holder(spec.second_key, location)
 
         if minute_holder is not None:
+            if (
+                self.device.device_type == DeviceType.OVEN
+                and spec.minute_key == ThinQProperty.REMAIN_MINUTE
+            ):
+                return OvenTimerPropertyState(
+                    hour_holder,
+                    minute_holder,
+                    second_holder,
+                    current_state_holder=self._get_holder(
+                        ThinQProperty.CURRENT_STATE, location
+                    ),
+                    time_format=spec.time_format,
+                    setter=spec.setter,
+                )
             return TimerPropertyState(
                 hour_holder,
                 minute_holder,
@@ -663,12 +678,14 @@ class HABridge:
 
         # Update all states.
         for state in self.state_map.values():
+            if isinstance(state, OvenTimerPropertyState):
+                state.record_timer_update(response)
             state.update(preferred_unit=self.preferred_temperature_unit)
 
         return self.state_map
 
     def update_status(
-        self, status: dict[str, Any] | None
+        self, status: dict[str, Any] | list[dict[str, Any]] | None
     ) -> dict[str, PropertyState] | None:
         """Update data manually."""
         if status is not None:
@@ -676,6 +693,8 @@ class HABridge:
 
         # Update all states.
         for state in self.state_map.values():
+            if isinstance(state, OvenTimerPropertyState):
+                state.record_timer_update(status)
             if isinstance(
                 state,
                 (

--- a/thinqconnect/integration/homeassistant/state.py
+++ b/thinqconnect/integration/homeassistant/state.py
@@ -7,7 +7,7 @@
 
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterable
-from datetime import time
+from datetime import datetime, time, timedelta, timezone
 from typing import Any
 
 from thinqconnect import ConnectBaseDevice, ThinQAPIException
@@ -320,6 +320,74 @@ class TimerPropertyState(PropertyState):
         if self.second_holder is not None:
             messages.append(f"{self.second_holder.dump()},")
         return "".join(messages)
+
+
+class OvenTimerPropertyState(TimerPropertyState):
+    """Expose a stable cook-timer end time using fresh per-cavity reports."""
+
+    def __init__(
+        self,
+        hour_holder: PropertyHolder | None,
+        minute_holder: PropertyHolder,
+        second_holder: PropertyHolder | None,
+        *,
+        current_state_holder: PropertyHolder | None,
+        time_format: str | None = None,
+        setter: Callable[[ConnectBaseDevice, time | None], Awaitable[None]]
+        | None = None,
+    ) -> None:
+        super().__init__(
+            hour_holder,
+            minute_holder,
+            second_holder,
+            time_format=time_format,
+            setter=setter,
+        )
+        self.current_state_holder = current_state_holder
+        self.end_time: datetime | None = None
+        self._timer_updated = True
+
+    def record_timer_update(
+        self, status: dict[str, Any] | list[dict[str, Any]] | None
+    ) -> None:
+        """Record remaining-time fields before partial updates lose their origin."""
+        if not isinstance(status, list):
+            return
+        for cavity in status:
+            location = cavity.get("location", {}).get("locationName", "").lower()
+            if location == self.location and any(
+                key in (cavity.get("timer") or {})
+                for key in ("remainHour", "remainMinute", "remainSecond")
+            ):
+                self._timer_updated = True
+                return
+
+    def update(self, *, preferred_unit: str | None = None) -> None:
+        """Clear inactive timers and re-anchor only on a fresh timer report."""
+        super().update(preferred_unit=preferred_unit)
+        timer_updated = self._timer_updated
+        self._timer_updated = False
+        current_state = (
+            self.current_state_holder.get_value()
+            if self.current_state_holder is not None
+            else None
+        )
+        if (
+            current_state not in {"preheating", "cooking_in_progress"}
+            or not isinstance(self.value, time)
+            or self.value == time.min
+        ):
+            self.end_time = None
+            return
+        if not timer_updated:
+            return
+        end_time = datetime.now(timezone.utc) + timedelta(
+            hours=self.value.hour, minutes=self.value.minute, seconds=self.value.second
+        )
+        if self.end_time is None or abs(end_time - self.end_time) > timedelta(
+            seconds=5
+        ):
+            self.end_time = end_time
 
 
 class TemperaturePropertyState(PropertyState):


### PR DESCRIPTION
I’m adding oven remaining-time sensors to Home Assistant. Partial ThinQ updates retain omitted timer fields, so a status-only update when a new cook starts can make the previous cook’s cached duration look like a new timer.

This adds `OvenTimerPropertyState` for oven remaining-time properties. It exposes an `end_time` timestamp, tracks actual timer reports for each cavity, and clears the finish time when the timer is canceled or cooking ends. A fresh timer with the same duration can start again. Normal countdown reports keep the finish time stable within a five-second tolerance. The existing duration in `value` is preserved.

Both polling and push updates use this state through `HABridge`, keeping the device-specific logic in the SDK.

Validation:

- All 51 SDK tests pass (`python -m pytest -q tests`), covering upper, lower, and single-cavity locations with synthetic fixtures.
- All 77 LG ThinQ integration tests and 86 snapshots pass with the patched library.
- I tested a locally packaged build on my LG `LgTG4715ST.BSTELGA`, firmware `SAA39155903.00003483.0`, using Home Assistant Core 2026.9.1, and the updated timer behavior works.

Related Home Assistant draft PR: https://github.com/home-assistant/core/pull/181592. It depends on this library change being accepted and released.
